### PR TITLE
Fix global CLI installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,7 @@ console.log(`Success rate: ${metrics.successfulRequests / metrics.totalRequests 
 The `crawlee-scraper` CLI provides several commands to manage your scraping projects.
 These commands can be run using `pnpm crawlee-scraper <command>` or `npx crawlee-scraper <command>` if `crawlee-scraper-toolkit` is a project dependency (as shown in the Quick Start).
 If you've installed `crawlee-scraper-toolkit` globally (e.g., `pnpm add -g crawlee-scraper-toolkit`), you can invoke the commands directly: `crawlee-scraper <command>`.
+When installing from a local clone of this repository, run `pnpm install && pnpm run build` beforehand so the compiled CLI is generated with its path aliases properly resolved.
 Alternatively, `pnpm dlx crawlee-scraper <command>` can be used to ensure you're executing the latest version of the CLI without local installation.
 
 ### Generate Scraper

--- a/package.json
+++ b/package.json
@@ -119,6 +119,7 @@
     "semantic-release": "^24.2.5",
     "ts-jest": "^29.2.0",
     "ts-node": "^10.9.2",
+    "tsc-alias": "^1.8.6",
     "tsconfig-paths": "^4.2.0",
     "typedoc": "^0.28.5",
     "typedoc-plugin-markdown": "^4.6.4",

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -13,6 +13,8 @@ rm -rf dist/
 # Run TypeScript compiler
 echo "📦 Compiling TypeScript..."
 pnpm exec tsc
+echo "🔄 Rewriting path aliases..."
+pnpm exec tsc-alias
 
 # Make CLI executable
 echo "🔧 Making CLI executable..."


### PR DESCRIPTION
## Summary
- run `tsc-alias` in build script so compiled CLI has resolved paths
- document building before global install
- include `tsc-alias` as a dev dependency

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6845fd0011948322b8e9d7b0eb17261c